### PR TITLE
Add bcmath dependency to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0"
+        "php": "^7.3|^8.0",
+        "ext-bcmath": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5|^8.0"


### PR DESCRIPTION
Thanks for making this module, it's been really useful. I recently discovered that if bcmath is not installed all legacy validation will return false without showing any errors or failures in the code. 

Adding bcmath as a dependency should make this problem visible during dependency installation. 